### PR TITLE
feat: use gatsby-plugin-git-lastmod

### DIFF
--- a/gatsby-config.ts
+++ b/gatsby-config.ts
@@ -218,6 +218,12 @@ const config: GatsbyConfig = {
         fetchOptions: {},
       },
     },
+    {
+      resolve: `gatsby-plugin-git-lastmod`,
+      options: {
+        useFallback: false,
+      },
+    },
   ],
 }
 

--- a/gatsby-node.ts
+++ b/gatsby-node.ts
@@ -1,6 +1,5 @@
 import { CreateNodeArgs, CreatePageArgs, CreatePagesArgs } from "gatsby"
 const readingTime = require(`reading-time`)
-const simpleGit = require(`simple-git`)
 const path = require(`path`)
 
 const postTemplate = path.resolve(`./src/templates/BlogPost/BlogPost.tsx`)
@@ -78,19 +77,8 @@ exports.createPages = async ({
   })
 }
 
-exports.onCreatePage = async ({ page, actions }: CreatePageArgs) => {
+exports.onCreatePage = ({ page, actions }: CreatePageArgs) => {
   const { createPage } = actions
-
-  /***
-   * Add last modified date for sitemap using component name
-   * unless it is an mdx blog post, in which case use contentFilePath
-   ***/
-  const filePath = page.component.split("?__contentFilePath=").pop()
-  const fileLog = await simpleGit().log({
-    file: filePath,
-    maxCount: 1,
-    strictDate: true,
-  })
 
   /***
    * Add priority for sitemap
@@ -120,7 +108,6 @@ exports.onCreatePage = async ({ page, actions }: CreatePageArgs) => {
       ...page.context,
       priority: priority,
       changeFreq: changeFreq,
-      lastMod: fileLog?.latest?.date,
     },
   })
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "gatsby": "^5.6.0",
         "gatsby-plugin-canonical-urls": "^5.6.0",
         "gatsby-plugin-catch-links": "^5.6.0",
+        "gatsby-plugin-git-lastmod": "^0.1.2",
         "gatsby-plugin-image": "^3.6.0",
         "gatsby-plugin-manifest": "^5.6.0",
         "gatsby-plugin-mdx": "^5.6.0",
@@ -30,7 +31,6 @@
         "react-dom": "^18.2.0",
         "react-typography": "^0.16.23",
         "reading-time": "^1.5.0",
-        "simple-git": "^3.16.1",
         "typography": "^0.16.21"
       },
       "devDependencies": {
@@ -9934,6 +9934,22 @@
         "gatsby": "^5.0.0-next"
       }
     },
+    "node_modules/gatsby-plugin-git-lastmod": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/gatsby-plugin-git-lastmod/-/gatsby-plugin-git-lastmod-0.1.2.tgz",
+      "integrity": "sha512-KiuQuNZ+mbWE0YHrxxN0xIlJr9H7LE/ao2Xd7atb5mhd3XrvI8tQx/XzsJJq1uVN51kxuP/vCJF9VsggryWeew==",
+      "dependencies": {
+        "simple-git": "^3.17.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "gatsby": "^5.0.0",
+        "react": "^18.0.0 || ^0.0.0",
+        "react-dom": "^18.0.0 || ^0.0.0"
+      }
+    },
     "node_modules/gatsby-plugin-image": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/gatsby-plugin-image/-/gatsby-plugin-image-3.6.0.tgz",
@@ -17040,9 +17056,9 @@
       }
     },
     "node_modules/simple-git": {
-      "version": "3.16.1",
-      "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-3.16.1.tgz",
-      "integrity": "sha512-xzRxMKiy1zEYeHGXgAzvuXffDS0xgsq07Oi4LWEEcVH29vLpcZ2tyQRWyK0NLLlCVaKysZeem5tC1qHEOxsKwA==",
+      "version": "3.17.0",
+      "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-3.17.0.tgz",
+      "integrity": "sha512-JozI/s8jr3nvLd9yn2jzPVHnhVzt7t7QWfcIoDcqRIGN+f1IINGv52xoZti2kkYfoRhhRvzMSNPfogHMp97rlw==",
       "dependencies": {
         "@kwsites/file-exists": "^1.1.1",
         "@kwsites/promise-deferred": "^1.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "portfolio",
-  "version": "3.3.1",
+  "version": "3.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "portfolio",
-      "version": "3.3.1",
+      "version": "3.3.2",
       "license": "MIT",
       "dependencies": {
         "@mdx-js/react": "^2.3.0",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "gatsby": "^5.6.0",
     "gatsby-plugin-canonical-urls": "^5.6.0",
     "gatsby-plugin-catch-links": "^5.6.0",
+    "gatsby-plugin-git-lastmod": "^0.1.2",
     "gatsby-plugin-image": "^3.6.0",
     "gatsby-plugin-manifest": "^5.6.0",
     "gatsby-plugin-mdx": "^5.6.0",
@@ -51,7 +52,6 @@
     "react-dom": "^18.2.0",
     "react-typography": "^0.16.23",
     "reading-time": "^1.5.0",
-    "simple-git": "^3.16.1",
     "typography": "^0.16.21"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portfolio",
-  "version": "3.3.1",
+  "version": "3.3.2",
   "private": true,
   "description": "Fast, modern portfolio and blog powered by Gatsby",
   "license": "MIT",


### PR DESCRIPTION
<!-- Note: please make use of Conventional Commit messages, as they are used for generating changelogs. You can learn more about Conventional Commits here: https://www.conventionalcommits.org/en/v1.0.0/ -->

## Description

Use gatsby-plugin-git-lastmod to set `lastmod` field in sitemap.